### PR TITLE
Leap ahead param

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val commonSettings = Seq(
     "-Xlint:inaccessible",               // Warn about inacces(sible types in method signatures.
     "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
     "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+//    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
     "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
     "-Xlint:option-implicit",            // Option.apply used implicit view.
     "-Xlint:package-object-classes",     // Class or object defined in package object.

--- a/common-web/shared/src/main/scala/JourneyConfig.scala
+++ b/common-web/shared/src/main/scala/JourneyConfig.scala
@@ -4,7 +4,7 @@ package common.web
 /**
   *
   * @param leapAhead
-  *                  fast forward to the first empty question in a journey
+  *                  enables 'leap ahead' behaviour when requested as a parameter
   * @param askFirstListItem
   *                         when asking for list A with a minimum number of A required then go straight to add A subjourney
   *                         rather than to the empty listing index page

--- a/common-web/shared/src/main/scala/PageIn.scala
+++ b/common-web/shared/src/main/scala/PageIn.scala
@@ -8,14 +8,30 @@ case class PageIn[Html](
   state: DB,
   pathPrefix: List[String],
   config: JourneyConfig,
-  messages: UniformMessages[Html]
+  messages: UniformMessages[Html],
+  queryParams: Map[String, Seq[String]]
 ) {
+
+  def trackLeapPoint(state: DB): DB = {
+    queryParams.get("leap-to") match {
+      case Some(x :: Nil) =>
+        println(state)
+        val newState = state + (
+          ("_leap-to"   :: Nil) -> x,
+          ("_leap-from" :: Nil) -> targetId.mkString("/")
+        )
+        println(newState)
+        newState
+      case _       => state
+    }
+  }
+
   def toPageOut[A](
     output: AskResult[Html, A],
     stateManipulation: DB => DB = identity
   ): PageOut[Html,A] = PageOut[Html, A](
     breadcrumbs,
-    stateManipulation(state),
+    trackLeapPoint(stateManipulation(state)),
     output,
     pathPrefix,
     config

--- a/common-web/shared/src/main/scala/PageIn.scala
+++ b/common-web/shared/src/main/scala/PageIn.scala
@@ -15,12 +15,12 @@ case class PageIn[Html](
   def trackLeapPoint(state: DB): DB = {
     queryParams.get("leap-to") match {
       case Some(x :: Nil) =>
-        println(state)
+//        println(state)
         val newState = state + (
           ("_leap-to"   :: Nil) -> x,
           ("_leap-from" :: Nil) -> targetId.mkString("/")
         )
-        println(newState)
+//        println(newState)
         newState
       case _       => state
     }

--- a/common-web/shared/src/main/scala/PageIn.scala
+++ b/common-web/shared/src/main/scala/PageIn.scala
@@ -12,26 +12,12 @@ case class PageIn[Html](
   queryParams: Map[String, Seq[String]]
 ) {
 
-  def trackLeapPoint(state: DB): DB = {
-    queryParams.get("leap-to") match {
-      case Some(x :: Nil) =>
-//        println(state)
-        val newState = state + (
-          ("_leap-to"   :: Nil) -> x,
-          ("_leap-from" :: Nil) -> targetId.mkString("/")
-        )
-//        println(newState)
-        newState
-      case _       => state
-    }
-  }
-
   def toPageOut[A](
     output: AskResult[Html, A],
     stateManipulation: DB => DB = identity
   ): PageOut[Html,A] = PageOut[Html, A](
     breadcrumbs,
-    trackLeapPoint(stateManipulation(state)),
+    stateManipulation(state),
     output,
     pathPrefix,
     config

--- a/interpreter-play/shared/src/main/scala/PlayInterpreter.scala
+++ b/interpreter-play/shared/src/main/scala/PlayInterpreter.scala
@@ -21,9 +21,10 @@ trait PlayInterpreter[Html] extends Results with WebInterpreter[Html] {
   implicit class PlayWebMonad[A, Req <: Request[AnyContent]](wm: WebMonad[Html, A]) {
     import cats.implicits._
     def runSync(
-      path: String,     purgeStateUponCompletion: Boolean = false,
+      path: String,
+      purgeStateUponCompletion: Boolean = false,
       config: JourneyConfig = JourneyConfig()
-               )(
+    )(
       f: A => Result
     )(implicit
       request: Req,
@@ -50,7 +51,7 @@ trait PlayInterpreter[Html] extends Results with WebInterpreter[Html] {
       }
 
       persistence(request) { db =>
-        wm(PageIn(id, Nil, data, db, Nil, config, messages)) flatMap {
+        wm(PageIn(id, Nil, data, db, Nil, config, messages, request.queryString)) flatMap {
           case common.web.PageOut(breadcrumbs, dbOut, pageOut, _, _) =>
             pageOut match {
               case AskResult.GotoPath(targetPath) =>


### PR DESCRIPTION
Adds in support for leap ahead behaviour using a query parameter. 

Using this technique it is possible to construct a link that allows revisiting a page and returning back to the referrer (or another page) once the step is resubmitted. 

This respects subpages and the integrity of the journey logic (it will go to the last possible page if it cannot return to the referrer). 