### PR TITLE
Add defaultAsEntry to journeyConfig

### DIFF
--- a/common-web/shared/src/main/scala/JourneyConfig.scala
+++ b/common-web/shared/src/main/scala/JourneyConfig.scala
@@ -8,8 +8,11 @@ package common.web
   * @param askFirstListItem
   *                         when asking for list A with a minimum number of A required then go straight to add A subjourney
   *                         rather than to the empty listing index page
+  * @param defaultAsEntry
+  *                  treat a default value as though it has been entered by the user (allow bypassing)
   */
 case class JourneyConfig(
   leapAhead: Boolean = true,
-  askFirstListItem: Boolean = false
+  askFirstListItem: Boolean = false,
+  defaultAsEntry: Boolean = false
 )

--- a/common-web/shared/src/main/scala/PostAndGetPage.scala
+++ b/common-web/shared/src/main/scala/PostAndGetPage.scala
@@ -69,7 +69,6 @@ trait PostAndGetPage[Html, T, A] extends WebInteraction[Html, T, A] {
     def apply(pageInPreLeapPoint: PageIn[Html])(implicit ec: ExecutionContext): Future[PageOut[Html, A]] = {
       val (pageIn, leapAhead) = trackLeapPoint(pageInPreLeapPoint, id)
 //      import pageIn.{messages => _, _}
-
       val messages = pageIn.messages.withCustomContent(customContent)
       val currentId = pageIn.pathPrefix :+ id
 
@@ -78,7 +77,7 @@ trait PostAndGetPage[Html, T, A] extends WebInteraction[Html, T, A] {
 
       lazy val dbObject: Option[Either[ErrorTree,A]] = {
         val fromState = dbInput map {_ >>= codec.decode >>= validation.either}
-        if (leapAhead) {
+        if (leapAhead || pageIn.config.defaultAsEntry) {
           fromState orElse default.map(validation.either)
         } else {
           fromState


### PR DESCRIPTION
A feature requested from HMRC - this allows the web interpreter to treat the default values as though they have been entered by the user. When selecting a URL manually this allows bypassing pages that have defaults. Disabled by default as it compromises non-repudiation and is possibly indicative of bad journey design. 

